### PR TITLE
CodiceFiscale::Helpers.intersection#L5 "conflicts" with ActiveSupport Array.split method

### DIFF
--- a/lib/codice_fiscale/helpers.rb
+++ b/lib/codice_fiscale/helpers.rb
@@ -1,22 +1,20 @@
 module CodiceFiscale
   module Helpers
-    def intersection string_a, string_or_array_b
-      letters_a = string_a.split ''
-      letters_b = string_or_array_b.respond_to?(:split) ? string_or_array_b.split('') : string_or_array_b
-      selected_letters = letters_a.select { |letter| letters_b.include? letter }
-      selected_letters.join ''
+
+    def multiset_intersection array_a, array_b
+      array_a.select { |letter| array_b.include? letter }
     end
 
     def consonants string
-      intersection string, Alphabet.consonants
+      multiset_intersection(string.chars, Alphabet.consonants).join
     end
 
     def first_three_consonants string
-      intersection(string, Alphabet.consonants)[0..2]
+      multiset_intersection(string.chars, Alphabet.consonants)[0..2].join
     end
 
     def first_three_vowels string
-      intersection(string, Alphabet.vowels)[0..2]
+      multiset_intersection(string.chars, Alphabet.vowels)[0..2].join
     end
 
     def truncate_and_right_pad_with_three_x string
@@ -29,5 +27,6 @@ module CodiceFiscale
       code << first_three_vowels(string)
       truncate_and_right_pad_with_three_x code
     end
+
   end
 end

--- a/spec/lib/codice_fiscale/fiscal_code_spec.rb
+++ b/spec/lib/codice_fiscale/fiscal_code_spec.rb
@@ -110,7 +110,7 @@ describe CodiceFiscale::FiscalCode do
       end
 
       context 'when codes are fetched using csv' do
-        before { CodiceFiscale::Codes.stub!(:city).and_return('hello') }
+        before { CodiceFiscale::Codes.stub(:city).and_return('hello') }
 
         it 'returns the city code' do
           fiscal_code.birthplace_part.should == 'hello'
@@ -130,7 +130,7 @@ describe CodiceFiscale::FiscalCode do
       end
 
       context 'when codes are fetched using csv' do
-        before { CodiceFiscale::Codes.stub!(:country).and_return('Middle-Earth') }
+        before { CodiceFiscale::Codes.stub(:country).and_return('Middle-Earth') }
 
         it 'returns the country code' do
           fiscal_code.birthplace_part.should == 'Middle-Earth'


### PR DESCRIPTION
In a Rails app `string_or_array_b.respond_to?(:split)` returns true when an array is given (see line 5). This is because Active Support extends Array object with a `split` method.

I've also refactored the `intersection` method a bit :)

Dumitru.
