### PR TITLE
Don't call upcase! and preserve original values

### DIFF
--- a/lib/codice_fiscale/helpers.rb
+++ b/lib/codice_fiscale/helpers.rb
@@ -22,9 +22,9 @@ module CodiceFiscale
     end
 
     def first_three_consonants_than_vowels string
-      string.upcase!
-      code = first_three_consonants string
-      code << first_three_vowels(string)
+      upcase_string = string.upcase
+      code = first_three_consonants upcase_string
+      code << first_three_vowels(upcase_string)
       truncate_and_right_pad_with_three_x code
     end
 


### PR DESCRIPTION
The `upcase!` call is modifying the params passed to the method call, which can be a pain to debug since it's not a clear result. Example:

```
> test = 'Alessio'
> CodiceFiscale.calculate(name: test,.... )
// Calculated Value
> test == 'ALESSIO'
true
```

If this is used in an ActiveRecord validation, the upcase value will be passed along and it will be stored in the database as upcase instead of having its original capitalization. Right now I'm using 

```
CodiceFiscale.calculate(name: name.dup...)
```

But it seems like an unnecessary thing to do, a library should never change the values I pass to it unless it's a bang method. 